### PR TITLE
Make PointCloudBuilder.ids int again

### DIFF
--- a/camtrack/_camtrack.py
+++ b/camtrack/_camtrack.py
@@ -273,7 +273,7 @@ class PointCloudBuilder:
         yield self.colors
 
     def add_points(self, ids: np.ndarray, points: np.ndarray) -> None:
-        self._ids = np.vstack((self.ids, ids.reshape(-1, 1)))
+        self._ids = np.vstack((self.ids, ids.reshape(-1, 1))).astype(np.int)
         self._points = np.vstack((self.points, points.reshape(-1, 3)))
         self._sort_data()
 


### PR DESCRIPTION
При добавлении точек в пустой PointCloudBuilder внутренние ids становятся float по умолчанию. Предлагаю исправление.